### PR TITLE
Add tag support by name convention

### DIFF
--- a/metrics_reporter.go
+++ b/metrics_reporter.go
@@ -5,6 +5,8 @@ package datadog
 import (
 	"github.com/rcrowley/go-metrics"
 	"log"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -12,6 +14,10 @@ type MetricsReporter struct {
 	client   *Client
 	registry metrics.Registry
 }
+
+// Expect the tags in the pattern
+// namespace.metricName[tag1:value1,tag2:value2,etc....]
+var tagPattern = regexp.MustCompile("([\\w\\.]+)\\[([\\w\\W]+)\\]")
 
 // Create an un-started MetricsReporter. In most circumstances, the
 // `metrics.DefaultRegistry` will suffice for the required `metrics.Registry`.
@@ -78,70 +84,75 @@ func (mr *MetricsReporter) series(t int64, name string, i interface{}) []*Series
 	return nil
 }
 
-func (mr *MetricsReporter) counterSeries(t int64, name string,
+func (mr *MetricsReporter) counterSeries(t int64, id string,
 	counter metrics.Counter) []*Series {
+	name, tags := splitNameAndTags(id)
 	counter.Inc(0)
 	return []*Series{
-		mr.counterI(name+".count", t, counter.Count()),
+		mr.counterI(name+".count", t, counter.Count(), tags),
 	}
 }
 
-func (mr *MetricsReporter) gaugeSeries(t int64, name string,
+func (mr *MetricsReporter) gaugeSeries(t int64, id string,
 	gauge metrics.Gauge) []*Series {
+	name, tags := splitNameAndTags(id)
 	return []*Series{
-		mr.gaugeI(name+".value", t, gauge.Value()),
+		mr.gaugeI(name+".value", t, gauge.Value(), tags),
 	}
 }
 
-func (mr *MetricsReporter) histogramSeries(t int64, name string,
+func (mr *MetricsReporter) histogramSeries(t int64, id string,
 	h metrics.Histogram) []*Series {
 	ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+	name, tags := splitNameAndTags(id)
 
 	return []*Series{
-		mr.counterI(name+".count", t, h.Count()),
-		mr.counterI(name+".min", t, h.Min()),
-		mr.counterI(name+".max", t, h.Max()),
-		mr.counterF(name+".mean", t, h.Mean()),
-		mr.counterF(name+".stddev", t, h.StdDev()),
-		mr.counterF(name+".median", t, ps[0]),
-		mr.counterF(name+".percentile.75", t, ps[1]),
-		mr.counterF(name+".percentile.95", t, ps[2]),
-		mr.counterF(name+".percentile.99", t, ps[3]),
-		mr.counterF(name+".percentile.999", t, ps[4]),
+		mr.counterI(name+".count", t, h.Count(), tags),
+		mr.counterI(name+".min", t, h.Min(), tags),
+		mr.counterI(name+".max", t, h.Max(), tags),
+		mr.counterF(name+".mean", t, h.Mean(), tags),
+		mr.counterF(name+".stddev", t, h.StdDev(), tags),
+		mr.counterF(name+".median", t, ps[0], tags),
+		mr.counterF(name+".percentile.75", t, ps[1], tags),
+		mr.counterF(name+".percentile.95", t, ps[2], tags),
+		mr.counterF(name+".percentile.99", t, ps[3], tags),
+		mr.counterF(name+".percentile.999", t, ps[4], tags),
 	}
 }
 
-func (mr *MetricsReporter) meterSeries(t int64, name string,
+func (mr *MetricsReporter) meterSeries(t int64, id string,
 	m metrics.Meter) []*Series {
+	name, tags := splitNameAndTags(id)
 	m.Mark(0)
 	return []*Series{
-		mr.counterI(name+".count", t, m.Count()),
-		mr.counterF(name+".rate.1min", t, m.Rate1()),
-		mr.counterF(name+".rate.5min", t, m.Rate5()),
-		mr.counterF(name+".rate.15min", t, m.Rate15()),
-		mr.counterF(name+".rate.mean", t, m.RateMean()),
+		mr.counterI(name+".count", t, m.Count(), tags),
+		mr.counterF(name+".rate.1min", t, m.Rate1(), tags),
+		mr.counterF(name+".rate.5min", t, m.Rate5(), tags),
+		mr.counterF(name+".rate.15min", t, m.Rate15(), tags),
+		mr.counterF(name+".rate.mean", t, m.RateMean(), tags),
 	}
 }
 
-func (mr *MetricsReporter) timerSeries(t int64, name string,
+func (mr *MetricsReporter) timerSeries(t int64, id string,
 	m metrics.Timer) []*Series {
 	ps := m.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+	name, tags := splitNameAndTags(id)
 
 	return []*Series{
-		mr.counterI(name+".count", t, m.Count()),
-		mr.counterF(name+".min", t, millisI(m.Min())),
-		mr.counterF(name+".max", t, millisI(m.Max())),
-		mr.counterF(name+".mean", t, millisF(m.Mean())),
-		mr.counterF(name+".stddev", t, millisF(m.StdDev())),
-		mr.counterF(name+".median", t, millisF(ps[0])),
-		mr.counterF(name+".percentile.75", t, millisF(ps[1])),
-		mr.counterF(name+".percentile.95", t, millisF(ps[2])),
-		mr.counterF(name+".percentile.99", t, millisF(ps[3])),
-		mr.counterF(name+".percentile.999", t, millisF(ps[4])),
-		mr.counterF(name+".rate.1min", t, m.Rate1()),
-		mr.counterF(name+".rate.5min", t, m.Rate5()),
-		mr.counterF(name+".rate.15min", t, m.Rate15()),
-		mr.counterF(name+".rate.mean", t, m.RateMean()),
+		mr.counterI(name+".count", t, m.Count(), tags),
+		mr.counterF(name+".min", t, millisI(m.Min()), tags),
+		mr.counterF(name+".max", t, millisI(m.Max()), tags),
+		mr.counterF(name+".mean", t, millisF(m.Mean()), tags),
+		mr.counterF(name+".stddev", t, millisF(m.StdDev()), tags),
+		mr.counterF(name+".median", t, millisF(ps[0]), tags),
+		mr.counterF(name+".percentile.75", t, millisF(ps[1]), tags),
+		mr.counterF(name+".percentile.95", t, millisF(ps[2]), tags),
+		mr.counterF(name+".percentile.99", t, millisF(ps[3]), tags),
+		mr.counterF(name+".percentile.999", t, millisF(ps[4]), tags),
+		mr.counterF(name+".rate.1min", t, m.Rate1(), tags),
+		mr.counterF(name+".rate.5min", t, m.Rate5(), tags),
+		mr.counterF(name+".rate.15min", t, m.Rate15(), tags),
+		mr.counterF(name+".rate.mean", t, m.RateMean(), tags),
 	}
 }
 
@@ -159,32 +170,46 @@ func millisF(nanos float64) float64 {
 // 	return int64(nanos) / int64(time.Millisecond)
 // }
 
-func (mr *MetricsReporter) counterF(metric string, t int64, v float64) *Series {
-	return mr.seriesF(metric, "counter", t, v)
+func (mr *MetricsReporter) counterF(
+	metric string, t int64, v float64, tags []string) *Series {
+	return mr.seriesF(metric, "counter", t, v, tags)
 }
 
-func (mr *MetricsReporter) counterI(metric string, t int64, v int64) *Series {
-	return mr.seriesI(metric, "counter", t, v)
+func (mr *MetricsReporter) counterI(
+	metric string, t int64, v int64, tags []string) *Series {
+	return mr.seriesI(metric, "counter", t, v, tags)
 }
 
-func (mr *MetricsReporter) gaugeI(metric string, t int64, v int64) *Series {
-	return mr.seriesI(metric, "gauge", t, v)
+func (mr *MetricsReporter) gaugeI(
+	metric string, t int64, v int64, tags []string) *Series {
+	return mr.seriesI(metric, "gauge", t, v, tags)
 }
 
-func (mr *MetricsReporter) seriesF(metric, typ string, t int64, v float64) *Series {
+func (mr *MetricsReporter) seriesF(
+	metric, typ string, t int64, v float64, tags []string) *Series {
 	return &Series{
 		Metric: metric,
 		Points: [][2]interface{}{[2]interface{}{t, v}},
 		Type:   typ,
 		Host:   mr.client.Host,
+		Tags:   tags,
 	}
 }
 
-func (mr *MetricsReporter) seriesI(metric, typ string, t int64, v int64) *Series {
+func (mr *MetricsReporter) seriesI(
+	metric, typ string, t int64, v int64, tags []string) *Series {
 	return &Series{
 		Metric: metric,
 		Points: [][2]interface{}{[2]interface{}{t, v}},
 		Type:   typ,
 		Host:   mr.client.Host,
+		Tags:   tags,
 	}
+}
+
+func splitNameAndTags(metric string) (string, []string) {
+	if res := tagPattern.FindStringSubmatch(metric); len(res) == 3 {
+		return res[1], strings.Split(res[2], ",")
+	}
+	return metric, make([]string, 0)
 }

--- a/metrics_reporter_test.go
+++ b/metrics_reporter_test.go
@@ -155,3 +155,17 @@ func (_ *ReporterSuite) TestTimerSeries(c *C) {
 
 	c.Check(series[2].Metric, Equals, "my.timer.max")
 }
+
+func (_ *ReporterSuite) TestTaggedCounterSeries(c *C) {
+	counter := metrics.NewCounter()
+	counter.Inc(444)
+	counter.Inc(222)
+	series := reporter.series(
+		t.Unix(), "my.counter[food:bagels,drink:coffee]", counter)
+	c.Check(series, HasLen, 1)
+	s := series[0]
+	c.Check(s.Metric, Equals, "my.counter.count")
+	c.Check(s.Tags, HasLen, 2)
+	c.Check(s.Tags[0], Equals, "food:bagels")
+	c.Check(s.Tags[1], Equals, "drink:coffee")
+}


### PR DESCRIPTION
To tag a metric, name it like my.metric[tag1:foo,tag2:bar,...]
