### PR TITLE
Add Client Environment as tag to series if it exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ And to use a custom registry, it would simply read:
 ```go
 host _ := os.Hostname()
 dog := datadog.New(host, "dog-api-key")
-reporter := getMyCustomRegistry()
+registry := getMyCustomRegistry()
 go dog.Reporter(registry).Start(60 * time.Second)
 ```

--- a/client.go
+++ b/client.go
@@ -18,8 +18,9 @@ const (
 )
 
 type Client struct {
-	Host   string
-	ApiKey string
+	Host        string
+	ApiKey      string
+	Environment string
 }
 
 type seriesMessage struct {
@@ -49,6 +50,14 @@ func New(host, apiKey string) *Client {
 	return &Client{
 		Host:   host,
 		ApiKey: apiKey,
+	}
+}
+
+func NewWithEnv(host, apiKey, environment string) *Client {
+	return &Client{
+		Host:        host,
+		ApiKey:      apiKey,
+		Environment: environment,
 	}
 }
 

--- a/metrics_reporter.go
+++ b/metrics_reporter.go
@@ -187,6 +187,9 @@ func (mr *MetricsReporter) gaugeI(
 
 func (mr *MetricsReporter) seriesF(
 	metric, typ string, t int64, v float64, tags []string) *Series {
+	if mr.client.Environment != "" {
+		tags = append(tags, "environment:"+mr.client.Environment)
+	}
 	return &Series{
 		Metric: metric,
 		Points: [][2]interface{}{[2]interface{}{t, v}},
@@ -198,6 +201,9 @@ func (mr *MetricsReporter) seriesF(
 
 func (mr *MetricsReporter) seriesI(
 	metric, typ string, t int64, v int64, tags []string) *Series {
+	if mr.client.Environment != "" {
+		tags = append(tags, "environment:"+mr.client.Environment)
+	}
 	return &Series{
 		Metric: metric,
 		Points: [][2]interface{}{[2]interface{}{t, v}},

--- a/metrics_reporter_test.go
+++ b/metrics_reporter_test.go
@@ -169,3 +169,21 @@ func (_ *ReporterSuite) TestTaggedCounterSeries(c *C) {
 	c.Check(s.Tags[0], Equals, "food:bagels")
 	c.Check(s.Tags[1], Equals, "drink:coffee")
 }
+
+func (_ *ReporterSuite) TestClientWithEnv(c *C) {
+	client = &Client{
+		Host:        "My Host",
+		Environment: "staging",
+	}
+	reporter = &MetricsReporter{client, registry}
+
+	counter := metrics.NewCounter()
+	counter.Inc(666)
+
+	registry.Register("my.counter", counter)
+
+	series := reporter.Series()
+	s := series[0]
+	c.Check(s.Metric, Equals, "my.counter.count")
+	c.Check(s.Tags[0], Equals, "environment:staging")
+}


### PR DESCRIPTION
When creating a client, allow an environment to be passed that will be
set as a tag on the series.